### PR TITLE
fix deprecation warnings

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -18,7 +18,7 @@ case $"\([0-9]\)\.\([0-9]+\)\."
        OCAML_MINOR = $2
        export
 
-OCAMLFLAGS    = -w +a-3-4-32-44-48 -warn-error +a-3-4-6-7-9-18-27..29-32..99
+OCAMLFLAGS    = -w +a-4-32-44-48 -warn-error +a-3-4-6-7-9-18-27..29-32..99
 OCAMLOPTFLAGS = -g -inline 100
 OCAMLCFLAGS  += -g
 

--- a/compiler/extprotc.ml
+++ b/compiler/extprotc.ml
@@ -108,7 +108,7 @@ let () =
        let global_opts = if !nolocs then ["locs", "false"] else [] in
        let global_opts = match !fieldmod with
          | "" -> global_opts
-         | s -> ("field-module", String.capitalize s) :: global_opts in
+         | s -> ("field-module", String.capitalize_ascii s) :: global_opts in
        let global_opts = if !export_tys then ("export_tys", "") :: global_opts else global_opts in
        let global_opts = ("assume_subsets", !assume_subsets) :: global_opts in
        let () =

--- a/compiler/gen_OCaml.ml
+++ b/compiler/gen_OCaml.ml
@@ -364,9 +364,7 @@ let rec default_value (ev_regime : Gencode.ev_regime) t =
     | Bitstring32 _ -> None
     | Sum (l, _) -> begin (* first constant constructor = default*)
         match
-          try
-            Some (List.find_map (function `Constant x -> Some x | _ -> None) l)
-          with Not_found -> None
+          List.find_map_opt (function `Constant x -> Some x | _ -> None) l
         with
           | None -> None
           | Some c ->

--- a/opam
+++ b/opam
@@ -24,6 +24,6 @@ depends: [
   "ocamlfind" {build}
   "ounit" {test}
   "camlp4" {build}
-  ("extlib" | "extlib-compat")
+  ("extlib" {>= "1.7.7"} | "extlib-compat" {>="1.7.7"})
   "base-bytes"
 ]

--- a/runtime/error.ml
+++ b/runtime/error.ml
@@ -28,9 +28,9 @@ let rec pp_location pp = function
   | Field (field, loc) ->
       PP.fprintf pp "@[<1>%s.@,%a@]" field pp_location loc
   | Message (msg, constr, loc) -> match constr with
-        None -> PP.fprintf pp "@[<1>%s.@,%a@]" (String.capitalize msg) pp_location loc
+        None -> PP.fprintf pp "@[<1>%s.@,%a@]" (String.capitalize_ascii msg) pp_location loc
       | Some c -> PP.fprintf pp "@[<1>%s_%s.@,%a@]"
-                    (String.capitalize msg) (String.capitalize c) pp_location loc
+                    (String.capitalize_ascii msg) (String.capitalize_ascii c) pp_location loc
 
 let pp_format_error pp = function
   | Bad_wire_type ty ->

--- a/runtime/msg_buffer.ml
+++ b/runtime/msg_buffer.ml
@@ -108,7 +108,7 @@ let resize b more =
 let add_char b c =
   let pos = b.position in
   if pos >= b.length then resize b 1;
-  b.buffer.[pos] <- c;
+  Bytes.set b.buffer pos c;
   b.position <- pos + 1
 
 let add_substring b s offset len =

--- a/runtime/random_gen.ml
+++ b/runtime/random_gen.ml
@@ -67,7 +67,7 @@ struct
       let s = Bytes.create n in
       let rec loop = function
           n when n < 0 -> return @@ Bytes.unsafe_to_string s
-        | n -> rand_integer 255 >>= fun c -> s.[n] <- Char.chr c; loop (n - 1)
+        | n -> rand_integer 255 >>= fun c -> Bytes.set s n (Char.chr c); loop (n - 1)
       in loop (n - 1)
 
   let rand_readable_string len =
@@ -75,7 +75,7 @@ struct
       let s = Bytes.create n in
       let rec loop = function
           n when n < 0 -> return @@ Bytes.unsafe_to_string s
-        | n -> rand_integer (127 - 32) >>= fun c -> s.[n] <- Char.chr (32 + c); loop (n - 1)
+        | n -> rand_integer (127 - 32) >>= fun c -> Bytes.set s n (Char.chr (32 + c)); loop (n - 1)
       in loop (n - 1)
 
   let rand_int =


### PR DESCRIPTION
In particular this enables build with extlib 1.7.8 (where type of List.find_map was changed to match stdlib).